### PR TITLE
Speed up merging by straight up copying unique term lists

### DIFF
--- a/include/irkit/coding.hpp
+++ b/include/irkit/coding.hpp
@@ -102,10 +102,22 @@ using any_codec = boost::type_erasure::any<boost::mpl::vector<has_encode<S, T>,
     boost::type_erasure::copy_constructible<S>,
     boost::type_erasure::assignable<S>>>;
 
-};  // namespace irk
+template<class, class, class = void>
+struct has_pointer_decode : std::false_type {};
 
-//! Codecs and coding utilities.
-namespace irk {
+template<class Codec, class T>
+struct has_pointer_decode<Codec,
+    T,
+    std::void_t<decltype(std::declval<T>().decode(std::declval<T>(),
+        std::declval<std::ostream&>()))>> : std::true_type {};
+
+// TODO:
+//template<class T, class Codec>
+//T decode(const char* data, const any_codec<T>& codec)
+//{
+//    if constexpr () {
+//    }
+//}
 
 //! Encodes a range of integer values to an output stream.
 /*!

--- a/include/irkit/index/assembler.hpp
+++ b/include/irkit/index/assembler.hpp
@@ -150,8 +150,6 @@ public:
             batch_metadata.term_occurrences.c_str());
         std::ofstream of_properties(batch_metadata.properties.c_str());
 
-        std::cout << "initializing builder: "
-            << first_id << "-" << batch_size_ + first_id - 1 << std::endl;
         builder_type builder(block_size_);
         std::string line;
         for (int processed_documents_ = first_id;
@@ -160,7 +158,6 @@ public:
         {
             if (!std::getline(input, line)) { break; }
             document_type doc = document_type(processed_documents_);
-            std::cout << "adding document " << doc << std::endl;
             builder.add_document(doc);
             std::istringstream linestream(line);
             std::string title;

--- a/include/irkit/index/block_inverted_list.hpp
+++ b/include/irkit/index/block_inverted_list.hpp
@@ -342,6 +342,8 @@ public:
         vb.decode(istr, block_size_);
         vb.decode(istr, num_blocks);
 
+        memory_ = irk::make_memory_view(list_ptr, list_byte_size);
+
         std::vector<long> skips = irk::decode_n(istr, num_blocks, vb);
         std::vector<value_type> last_documents = irk::decode_delta_n(
             istr, num_blocks, codec_);
@@ -368,6 +370,12 @@ public:
     iterator lookup(value_type id) const { return begin().nextgeq(id); };
 
     long size() const { return length_; }
+    long memory_size() const { return memory_.size(); }
+
+    std::ostream write(std::ostream& out) const
+    {
+        return out.write(memory_.data(), memory_.size());
+    }
 
 private:
     friend class block_iterator<self_type, true>;
@@ -375,6 +383,7 @@ private:
     any_codec<Doc> codec_;
     std::vector<irk::index::block_view<value_type>> blocks_;
     long block_size_;
+    irk::memory_view memory_;
 };
 
 //! A view of a block payload list.
@@ -422,6 +431,8 @@ public:
         vb.decode(istr, block_size_);
         vb.decode(istr, num_blocks);
 
+        memory_ = irk::make_memory_view(list_ptr, list_byte_size);
+
         std::vector<long> skips = irk::decode_n(istr, num_blocks, vb);
 
         int running_offset = offset + istr.tellg();
@@ -441,6 +452,12 @@ public:
         return iterator{*this, length_ / block_size_, length_ % block_size_};
     };
     long size() const { return length_; }
+    long memory_size() const { return memory_.size(); }
+
+    std::ostream write(std::ostream& out) const
+    {
+        return out.write(memory_.data(), memory_.size());
+    }
 
 private:
     friend class block_iterator<self_type, false>;
@@ -448,6 +465,7 @@ private:
     any_codec<Payload> codec_;
     std::vector<irk::index::block_view<>> blocks_;
     long block_size_;
+    irk::memory_view memory_;
 };
 
 template<class ...Payload>

--- a/include/irkit/index/builder.hpp
+++ b/include/irkit/index/builder.hpp
@@ -90,13 +90,14 @@ public:
     void add_term(const term_type& term)
     {
         ++all_occurrences_;
-        ++document_sizes_[current_doc_];
+        ++document_sizes_.back();
         auto ti = term_map_.find(term);
         if (ti != term_map_.end()) {
             term_id_type term_id = ti->second;
             if (postings_[term_id].back().doc == current_doc_) {
                 postings_[term_id].back().freq++;
             } else {
+                std::cout << "pushing new doc to term " << term_id << ": " << current_doc_ << std::endl;
                 postings_[term_id].push_back({current_doc_, 1});
             }
             term_occurrences_[term_id]++;

--- a/include/irkit/index/builder.hpp
+++ b/include/irkit/index/builder.hpp
@@ -97,7 +97,6 @@ public:
             if (postings_[term_id].back().doc == current_doc_) {
                 postings_[term_id].back().freq++;
             } else {
-                std::cout << "pushing new doc to term " << term_id << ": " << current_doc_ << std::endl;
                 postings_[term_id].push_back({current_doc_, 1});
             }
             term_occurrences_[term_id]++;

--- a/include/irkit/index/merger.hpp
+++ b/include/irkit/index/merger.hpp
@@ -153,6 +153,7 @@ public:
             term_id, doc_ids_);
         count_offset_ += index_entry.index()->copy_frequency_list(
             term_id, doc_counts_);
+        term_dfs_.push_back(index_entry.index()->tdf(term_id));
         return index_entry.index()->term_occurrences(term_id);
     }
 
@@ -183,7 +184,8 @@ public:
             occurrences += e.index()->term_occurrences(e.current_term_id());
             auto pr = e.postings();
             for (const auto& p : pr) {
-                doc_ids.push_back(p.document() + e.shift());
+                //doc_ids.push_back(p.document() + e.shift());
+                doc_ids.push_back(p.document());
                 doc_counts.push_back(p.payload());
             }
         }

--- a/include/irkit/memoryview.hpp
+++ b/include/irkit/memoryview.hpp
@@ -72,6 +72,7 @@ public:
         : self_(std::make_shared<model<source_type>>(source))
     {}
 
+    memory_view() = default;
     memory_view(const memory_view& other) = default;
 
     //! Returns a pointer to the underlying data.


### PR DESCRIPTION
When only one batch index contains the term, we can copy everything. Since it happens a lot, it should speed up merging process significantly.

**Note:** Now batches must have globally consecutive document IDs, such that the first document ID in the second batch is the number of all documents in batch 1. This means we cannot merge indices that are not batches. Could be fixed later on.